### PR TITLE
withAuth HOC in Private Page layout

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ import Router from "next/router";
 
 type AuthContextType = {
   isAuthenticated: boolean;
+  isLoading: boolean;
   user: User | null;
   signIn: (data: SigninValues) => Promise<void>;
   logout: () => void;
@@ -33,15 +34,20 @@ type User = {
 
 export function AuthProvider({ children }: Props) {
   const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const isAuthenticated = !!user;
 
   useEffect(() => {
     const { "nextjs-boilerplate-advanced.token": token } = parseCookies();
-    if (token) {
-      api.get("me").then(({ data }) => {
-        setUser(data);
-      });
+
+    if (!token) {
+      return setIsLoading(false);
     }
+
+    api.get("me").then(({ data }) => {
+      setUser(data);
+      setIsLoading(false);
+    });
   }, []);
 
   async function signIn(values: SigninValues) {
@@ -66,7 +72,9 @@ export function AuthProvider({ children }: Props) {
   }
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, signIn, logout, user }}>
+    <AuthContext.Provider
+      value={{ isAuthenticated, signIn, logout, user, isLoading }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,8 @@
+import { AuthContext } from "@/contexts/AuthContext";
+import { useContext } from "react";
+
+export default function useAuth() {
+  const authContext = useContext(AuthContext);
+
+  return authContext;
+}

--- a/src/layouts/PrivatePage.tsx
+++ b/src/layouts/PrivatePage.tsx
@@ -1,10 +1,12 @@
 import { Box, IconButton, Stack } from "@chakra-ui/react";
 import Image from "next/image";
-import React, { ReactNode, useCallback, useState } from "react";
+import React, { ReactNode, useCallback, useEffect, useState } from "react";
 import logo from "@/assets/logo.svg";
 import { MdMenu } from "react-icons/md";
 import MainDrawer from "@/components/MainDrawer";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import useAuth from "@/hooks/useAuth";
 
 type Props = {
   children: ReactNode;
@@ -60,4 +62,27 @@ function PrivatePage({ children, title = "" }: Props) {
   );
 }
 
-export default PrivatePage;
+const withAuth = (Component: typeof PrivatePage) => {
+  const AuthenticatedComponent = (props: Props) => {
+    const router = useRouter();
+    const { user, isLoading } = useAuth();
+    const [renderPage, setRenderPage] = useState(false);
+
+    useEffect(() => {
+      if (isLoading) return;
+
+      if (!user?.id) {
+        router.replace("/login");
+        return;
+      }
+
+      setRenderPage(true);
+    }, [router, user, isLoading]);
+
+    return renderPage ? <Component {...props} /> : null;
+  };
+
+  return AuthenticatedComponent;
+};
+
+export default withAuth(PrivatePage);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,8 +3,6 @@ import PrivatePage from "@/layouts/PrivatePage";
 import { Container, Text } from "@chakra-ui/react";
 import React, { ReactElement, useContext } from "react";
 import type { NextPageWithLayout } from "./_app";
-import { GetServerSideProps } from "next";
-import { parseCookies } from "nookies";
 
 const Index: NextPageWithLayout = () => {
   const { user } = useContext(AuthContext);
@@ -17,23 +15,6 @@ const Index: NextPageWithLayout = () => {
       </Text>
     </Container>
   );
-};
-
-export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  const { "nextjs-boilerplate-advanced.token": token } = parseCookies(ctx);
-
-  if (!token) {
-    return {
-      redirect: {
-        destination: "/login",
-        permanent: false,
-      },
-    };
-  }
-
-  return {
-    props: {},
-  };
 };
 
 Index.getLayout = function getLayout(page: ReactElement) {


### PR DESCRIPTION
# Description

When the user isn't authenticated and tries to access a private page (such as "/"), it should redirect the user to the "/login" page for authentication purposes. This already happens by the [`getServerSideProps`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props) function in the `/pages/index.tsx`:
```js
export const getServerSideProps: GetServerSideProps = async (ctx) => {
  const { "nextjs-boilerplate-advanced.token": token } = parseCookies(ctx);

  if (!token) {
    return {
      redirect: {
        destination: "/login",
        permanent: false,
      },
    };
  }

  return {
    props: {},
  };
};

```

*For our use case* at Inovan.do, the `getServerSideProps` function *does not work* as we deploy the NextJS apps as[ static exports](https://nextjs.org/docs/pages/building-your-application/deploying/static-exports). Also this implementation needs to be implemented in every private route for it to redirect to the "/login" page correctly.

Having this in mind, a specific project that used this boilerplate implemented this HOC and I would like to know if it's a good thing to bring it to the template repo.

- Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tried to access any private page (eg.: "/") without being authenticated, and expected to be redirected to the "/login" page.

## Did you test this update on all browsers? 

- [x] Chrome
- [ ] Safari
- [x] Firefox
- [ ] Edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
